### PR TITLE
chore: remove `:unneeded` due to deprecation

### DIFF
--- a/Formula/flyctl.rb
+++ b/Formula/flyctl.rb
@@ -6,7 +6,6 @@ class Flyctl < Formula
   desc ""
   homepage "https://fly.io"
   version "0.0.248"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
After updating homebrew to `3.2.17-31-g810992a` I was greeted with this notice:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the superfly/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/superfly/homebrew-tap/Formula/flyctl.rb:9
```

..so; thinking it should be safe to remove.